### PR TITLE
Fork the gem under a different name

### DIFF
--- a/lib/middleman-search/version.rb
+++ b/lib/middleman-search/version.rb
@@ -1,3 +1,3 @@
 module MiddlemanSearch
-  VERSION = "0.10.0"
+  VERSION = "0.11.0a"
 end

--- a/middleman-search.gemspec
+++ b/middleman-search.gemspec
@@ -4,13 +4,13 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'middleman-search/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "middleman-search"
+  spec.name          = "middleman-search-gds"
   spec.version       = MiddlemanSearch::VERSION
-  spec.authors       = ["Matías García Isaía", "Santiago Palladino"]
-  spec.email         = ["mgarcia@manas.com.ar", "spalladino@manas.com.ar"]
+  spec.authors       = ["Government Digital Service", "Matías García Isaía", "Santiago Palladino"]
+  spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk", "mgarcia@manas.com.ar", "spalladino@manas.com.ar"]
   spec.summary       = %q{LunrJS-based search for Middleman}
-  spec.description   = %q{LunrJS-based search for Middleman}
-  spec.homepage      = "http://github.com/manastech/middleman-search"
+  spec.description   = %q{LunrJS-based search for Middleman. This is an unofficial fork of the middleman-search gem.}
+  spec.homepage      = "http://github.com/alphagov/middleman-search"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
This may be temporary, but we are going to publish our fork
to rubygems under another name.

This will allow us to include this version as a dependency in the
govuk_tech_docs gem we publish here:
https://rubygems.org/gems/govuk_tech_docs

The difference between this and upstream is a change from therubyracer
to execjs. This fixes problems with middleman hanging in dev mode.
See https://github.com/manastech/middleman-search/pull/24 for more
details.