### PR TITLE
[DO NOT MERGE] Adds Jenkinsfile for gem deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,9 @@
+#!/usr/bin/env groovy
+
+library("govuk")
+
+node {
+  govuk.buildProject(overrideTestTask: {
+    // there are no tests in this repo, so the default `bundle exec rake` would fail
+  })
+}


### PR DESCRIPTION
Overrides the default test task as there are no tests in this repo.

Whilst #6 is the preferred approach, we don't have sign-off for GitHub Actions with respect to API credential management at this moment in time. So we'll go for the traditional Jenkins approach for now.