### PR TITLE
Specify gem name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,10 @@
 library("govuk")
 
 node {
-  govuk.buildProject(overrideTestTask: {
-    // there are no tests in this repo, so the default `bundle exec rake` would fail
-  })
+  govuk.buildProject(
+    gemName: "middleman-search-gds",
+    overrideTestTask: {
+      // there are no tests in this repo, so the default `bundle exec rake` would fail
+    },
+  )
 }


### PR DESCRIPTION
The Jenkinsfile added in https://github.com/alphagov/middleman-search/pull/7
didn't quite work as intended:
https://ci.integration.publishing.service.gov.uk/job/middleman-search/job/master/1/console

This is because by default govuk-jenkinslib will try to publish a
gem under the same name as the repo (middleman-search), as opposed
to the one specified in the gemspec file.
Luckily we can override it with the gemName parameter:

https://github.com/alphagov/govuk-jenkinslib/blob/9eb91cceddaa7c4ad3c6009d824d8d23e4da7d68/vars/govuk.groovy#L15-L19