### PR TITLE
0.11.2: Fix use of long-deprecated `File::exists?`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.11.2
+
+* No longer calls `File::exists?`, which was deleted from the standard library in [Ruby 3.2](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/).

--- a/lib/middleman-search/search-index-resource.rb
+++ b/lib/middleman-search/search-index-resource.rb
@@ -156,7 +156,7 @@ module Middleman
       def lunr_resource(resource_name)
         @lunr_dirs.flat_map do |dir|
           [File.join(dir, minified_path(resource_name)), File.join(dir, resource_name)]
-        end.detect { |file| File.exists? file } or raise "Couldn't find #{resource_name} nor #{minified_path(resource_name)} in #{@lunr_dirs.map {|dir| File.absolute_path dir }.join File::PATH_SEPARATOR}"
+        end.detect { |file| File.exist? file } or raise "Couldn't find #{resource_name} nor #{minified_path(resource_name)} in #{@lunr_dirs.map {|dir| File.absolute_path dir }.join File::PATH_SEPARATOR}"
       end
     end
   end

--- a/lib/middleman-search/version.rb
+++ b/lib/middleman-search/version.rb
@@ -1,3 +1,3 @@
 module MiddlemanSearch
-  VERSION = "0.11.1"
+  VERSION = "0.11.2"
 end


### PR DESCRIPTION
- Fix use of `File::exists?` (as opposed to `File::exist?`), which was a blocker for Ruby 3.2 compatibility — see _Removed methods_ in the [release notes](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/). (Doesn't necessarily mean we're compatible with 3.2 yet, just that we have one fewer blockers.)
- Increment the patch version.

No breaking changes or new features in this release.