### PR TITLE
Use a version of bundler that doesn't have CVE-2021-43809.

### DIFF
--- a/middleman-search-gds.gemspec
+++ b/middleman-search-gds.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "execjs", ["~> 2.6"]
   spec.add_dependency "nokogiri", ["~> 1.6"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Bundler 1 is obsolete and vulnerable.

Should address https://github.com/alphagov/middleman-search/security/dependabot/3.